### PR TITLE
Rebrand manifest

### DIFF
--- a/manifest/nordcraft.webmanifest
+++ b/manifest/nordcraft.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "toddle",
-  "short_name": "toddle",
+  "name": "Nordcraft",
+  "short_name": "Nordcraft",
   "icons": [
     {
       "src": "https://raw.githubusercontent.com/toddledev/resources/main/icons/android-chrome-192x192.png",
@@ -13,8 +13,8 @@
       "type": "image/png"
     }
   ],
-  "theme_color": "#171717",
-  "background_color": "#171717",
+  "theme_color": "#000000",
+  "background_color": "#000000",
   "display": "standalone",
-  "start_url": "https://toddle.dev"
+  "start_url": "https://nordcraft.com"
 }

--- a/manifest/nordcraft.webmanifest
+++ b/manifest/nordcraft.webmanifest
@@ -3,12 +3,12 @@
   "short_name": "Nordcraft",
   "icons": [
     {
-      "src": "https://raw.githubusercontent.com/toddledev/resources/main/icons/android-chrome-192x192.png",
+      "src": "https://raw.githubusercontent.com/nordcraftengine/resources/main/icons/android-chrome-192x192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "https://raw.githubusercontent.com/toddledev/resources/main/icons/android-chrome-512x512.png",
+      "src": "https://raw.githubusercontent.com/nordcraftengine/resources/main/icons/android-chrome-512x512.png",
       "sizes": "512x512",
       "type": "image/png"
     }


### PR DESCRIPTION
I'm confused that https://raw.githubusercontent.com/toddledev/resources/main/manifest/toddle.webmanifest is accessible via URL because toddledev doesn't exist 😓 

If you approve this I will also change the URL to the manifest in the editor in my browser title PR after confirming the manifest is accessible on https://raw.githubusercontent.com/nordcraftengine/resources/main/manifest/nordcraft.webmanifest